### PR TITLE
Add User Agent to pass CloudFlare Protection

### DIFF
--- a/ptt/http/http.go
+++ b/ptt/http/http.go
@@ -1,0 +1,17 @@
+package http
+
+import (
+	"net/http"
+)
+
+// simulate firefox browser
+const userAgent string = "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0"
+
+func HttpRequest(reqURL string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	return req, nil
+}

--- a/ptt/rss/rss.go
+++ b/ptt/rss/rss.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Ptt-Alertor/ptt-alertor/models/article"
+	pttHttp "github.com/Ptt-Alertor/ptt-alertor/ptt/http"
 	"github.com/mmcdole/gofeed"
 )
 
@@ -51,7 +52,11 @@ var client = http.Client{
 }
 
 func parseURL(feedURL string) (feed *gofeed.Feed, err error) {
-	resp, err := client.Get(feedURL)
+	req, err := pttHttp.HttpRequest(feedURL)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/ptt/web/crawler.go
+++ b/ptt/web/crawler.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/Ptt-Alertor/logrus"
 
 	"github.com/Ptt-Alertor/ptt-alertor/models/article"
+	pttHttp "github.com/Ptt-Alertor/ptt-alertor/ptt/http"
 
 	"regexp"
 
@@ -267,7 +268,11 @@ var client = &http.Client{
 }
 
 func fetchHTML(reqURL string) (doc *html.Node, err error) {
-	resp, err := client.Get(reqURL)
+	req, err := pttHttp.HttpRequest(reqURL)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil && resp == nil {
 		log.WithField("url", reqURL).WithError(err).Error("Fetch URL Failed")
 		return nil, err


### PR DESCRIPTION
We found the curl in local is pass but it's blocked by CloudFlare DDoS Protection on AWS instances, after trying we found it may related to AWS (https://developers.cloudflare.com/firewall/known-issues-and-faq/#how-do-i-create-an-exception-to-exclude-certain-requests-from-being-blocked-or-challenged) and User Agent.

## Experient on AWS

Pass

```
curl -A "aaa" https://www.ptt.cc/atom/money.xml
```

Block
```
curl -A "curl/aaa" https://www.ptt.cc/atom/money.xml
curl -A "Go-http-client/1.1" https://www.ptt.cc/atom/money.xml
curl -A "python-requests/2.25.0" https://www.ptt.cc/atom/money.xml
curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36" https://www.ptt.cc/atom/money.xml
```